### PR TITLE
Created new methods for gathering and obtaining Double attributes fro…

### DIFF
--- a/protocol/eGUT_experiments.xml
+++ b/protocol/eGUT_experiments.xml
@@ -2,7 +2,7 @@
 <document>
 	<simulation name="eGUT_experiments" outputfolder="../results" log="DEBUG"
 		comment="this is a file for testing purposes only.">
-		<timer stepSize="1.0" endOfSimulation="5.0" />
+		<timer stepSize="1.0[min]" endOfSimulation="5.0[min]" />
 		<speciesLib>
 			<!-- species/species library The species library contains all agent species 
 				in the simulations. This may include microbial species, plasmid and vector 
@@ -84,11 +84,11 @@
 
 		<compartment name="first">
 			<shape class="Rectangle">
-				<dimension name="X" isCyclic="true" targetResolution="1.0" max="40.0"/>
+				<dimension name="X" isCyclic="true" targetResolution="1.0" min="0.0[um]" max="40.0"/>
 				<dimension name="Y" isCyclic="false" targetResolution="1.0" max="40.0"/>
 			</shape>
 			<solutes>
-				<solute name="solute1" concentration="0.2" defaultDiffusivity="1.0" />
+				<solute name="solute1" concentration="0.2[ug·ml-1]" defaultDiffusivity="6.0[um+2·s-1]" />
 			</solutes>
 			<reactions>
 			</reactions>
@@ -102,16 +102,16 @@
 				</agent>
 				<agent>
 					<aspect name="species" type="PRIMARY" class="String" value="species2" />
-					<aspect name="mass" type="CALCULATED" class="NumberWithUnit" input="0.15[pg]"/>
+					<aspect name="mass" type="PRIMARY" class="Double" value="0.15"/>
 					<aspect name="density" type="PRIMARY" class="Double" value="1" />
-					<spawn number="6" domain="40.0,0.2" />
+					<spawn number="6" domain="40,0.2" />
 				</agent>
 			</agents>
 			<processManagers>
 				<process name="svgWriter" class="GraphicalOutput"  priority="-3"
 					firstStep="0.0"  timerStepSize="1.0">
 					<aspect name="solute" type="PRIMARY" class="String" value="solute1" />
-					<aspect name="maxConcentration" type="PRIMARY" class="Double" value="2.0" />
+					<aspect name="maxConcentration" type="PRIMARY" class="Double" value="2.0[pg*um-3*min-1]" />
 					<aspect name="outputWriter" type="PRIMARY" class="String" value="SvgExport" />
 				</process>
 				<process name="svgWriter" class="GraphicalOutput"  priority="-3"

--- a/src/aspect/calculated/NumberWithUnit.java
+++ b/src/aspect/calculated/NumberWithUnit.java
@@ -2,14 +2,10 @@ package aspect.calculated;
 
 
 import aspect.AspectInterface;
-import java.util.Map;
-
 import aspect.Calculated;
 import expression.Expression;
-import expression.Unit;
-import expression.Unit.SI;
 import idynomics.Idynomics;
-import utility.GenericTrio;
+import utility.Helper;
 
 public class NumberWithUnit extends Calculated {
 
@@ -18,7 +14,21 @@ public class NumberWithUnit extends Calculated {
 	@Override
 	public void setInput(String input)
 	{
-		this._value = new Expression( input ).format( Idynomics.unitSystem );
+		try
+		{
+			this._value = 
+				new Expression( input ).format( Idynomics.unitSystem );
+		}
+		catch (NumberFormatException | StringIndexOutOfBoundsException
+				| NullPointerException f)
+		{
+			input = Helper.obtainInput(null,
+					"The value " + input + "is not in the correct format for "
+					+ "the class NumberWithUnit. Please provide a double with "
+					+ "decimal point and optional valid unit in square "
+					+ "brackets.");
+			setInput(input);
+		}
 	}
 	
 	@Override

--- a/src/boundary/SpatialBoundary.java
+++ b/src/boundary/SpatialBoundary.java
@@ -64,9 +64,8 @@ public abstract class SpatialBoundary extends Boundary
 		
 		if ( this.needsLayerThickness() )
 		{
-			s = XmlHandler.obtainAttribute(xmlElement,
-					XmlRef.layerThickness, XmlRef.dimensionBoundary);
-			this.setLayerThickness(Double.valueOf(s));
+			this.setLayerThickness(XmlHandler.obtainDouble(xmlElement,
+					XmlRef.layerThickness, XmlRef.dimensionBoundary));
 		}
 	}
 	

--- a/src/boundary/library/ChemostatOut.java
+++ b/src/boundary/library/ChemostatOut.java
@@ -43,8 +43,8 @@ public class ChemostatOut extends ChemostatBoundary
 	public void instantiate(Element xmlElement, Settable parent) 
 	{
 		if (! XmlHandler.hasAttribute(xmlElement, XmlRef.constantVolume))
-			this.setVolumeFlowRate( Double.valueOf( XmlHandler.obtainAttribute( 
-					xmlElement, XmlRef.volumeFlowRate, this.defaultXmlTag())));
+			this.setVolumeFlowRate( XmlHandler.obtainDouble( 
+					xmlElement, XmlRef.volumeFlowRate, this.defaultXmlTag()));
 		else
 			this.constantVolume = true;
 		this._agentRemoval = Helper.setIfNone( Boolean.valueOf( 

--- a/src/boundary/library/ConstantConcentrationToChemostat.java
+++ b/src/boundary/library/ConstantConcentrationToChemostat.java
@@ -35,8 +35,8 @@ public class ConstantConcentrationToChemostat extends Boundary
 	@Override
 	public void instantiate(Element xmlElement, Settable parent) {
 
-		this.setVolumeFlowRate( Double.valueOf( XmlHandler.obtainAttribute( 
-				xmlElement, XmlRef.volumeFlowRate, this.defaultXmlTag() ) ) );
+		this.setVolumeFlowRate( XmlHandler.obtainDouble ( 
+				xmlElement, XmlRef.volumeFlowRate, this.defaultXmlTag() ) );
 		
 		NodeList childNodes = XmlHandler.getAll(xmlElement, XmlRef.solute);
 		Element childElem;

--- a/src/boundary/library/MembraneToChemostat.java
+++ b/src/boundary/library/MembraneToChemostat.java
@@ -38,8 +38,8 @@ public class MembraneToChemostat extends Boundary
 	@Override
 	public void instantiate(Element xmlElement, Settable parent) {
 
-		this._transferCoefficient = Double.valueOf( XmlHandler.obtainAttribute( 
-				xmlElement, XmlRef.transferCoefficient, this.defaultXmlTag() ) );
+		this._transferCoefficient =  XmlHandler.obtainDouble( 
+				xmlElement, XmlRef.transferCoefficient, this.defaultXmlTag() );
 		
 		this._volumeSpecific = Boolean.valueOf( XmlHandler.obtainAttribute( 
 				xmlElement, XmlRef.volumeSpecific, this.defaultXmlTag() ) );

--- a/src/boundary/spatialLibrary/FixedBoundary.java
+++ b/src/boundary/spatialLibrary/FixedBoundary.java
@@ -48,9 +48,8 @@ public class FixedBoundary extends SpatialBoundary implements Instantiable
 		{
 			name = XmlHandler.obtainAttribute(e,
 					XmlRef.nameAttribute, XmlRef.concentration);
-			concn = XmlHandler.obtainAttribute(e, 
-					XmlRef.concentration, XmlRef.concentration);
-			this.setConcentration(name, Double.valueOf(concn));
+			this.setConcentration(name, XmlHandler.obtainDouble(e, 
+					XmlRef.concentration, XmlRef.concentration));
 		}
 	}
 	

--- a/src/chemical/Chemical.java
+++ b/src/chemical/Chemical.java
@@ -11,6 +11,7 @@ import referenceLibrary.XmlRef;
 import settable.Attribute;
 import settable.Module;
 import settable.Settable;
+import utility.Helper;
 import settable.Module.Requirements;
 
 public class Chemical implements Settable, Instantiable
@@ -166,20 +167,15 @@ public class Chemical implements Settable, Instantiable
 		this._name = XmlHandler.obtainAttribute(
 				xmlElement, XmlRef.nameAttribute, this.defaultXmlTag() );
 		
-		this._formationGibbs = Double.valueOf( XmlHandler.obtainAttribute(
-				xmlElement, XmlRef.formationGibbs, this.defaultXmlTag() ) );
+		this._formationGibbs = XmlHandler.obtainDouble(
+				xmlElement, XmlRef.formationGibbs, this.defaultXmlTag() );
 		
 
 		setComposition( xmlElement.getAttribute( XmlRef.composition ) );
 		
-		if( XmlHandler.hasAttribute(xmlElement, XmlRef.oxidationState))
-		{
-			this._referenceOxidationState = Double.valueOf( 
-					XmlHandler.obtainAttribute(
-					xmlElement, XmlRef.oxidationState, this.defaultXmlTag() ) );
-		}
-		else
-			this._referenceOxidationState = estimateRefOxidationState(0);
+		this._referenceOxidationState = Helper.setIfNone(XmlHandler.
+				gatherDouble(xmlElement, XmlRef.oxidationState),
+				estimateRefOxidationState(0));
 	}
 
 	@Override

--- a/src/dataIO/ObjectFactory.java
+++ b/src/dataIO/ObjectFactory.java
@@ -10,6 +10,7 @@ import org.w3c.dom.Element;
 
 import agent.Body;
 import dataIO.Log.Tier;
+import expression.Expression;
 import generalInterfaces.Copyable;
 import idynomics.Idynomics;
 import instantiable.Instance;
@@ -146,8 +147,17 @@ public class ObjectFactory
 			}
 			catch(NumberFormatException e)
 			{
-				printReadError( input(input, elem), ObjectRef.DBL);
-				return null;
+				try
+				{
+					return (Double) new Expression( input(input, elem) ).format(
+							Idynomics.unitSystem );
+				}
+				catch (NumberFormatException | StringIndexOutOfBoundsException
+						| NullPointerException f)
+				{
+					printReadError( input(input, elem), ObjectRef.DBL);
+					return null;
+				}
 			}
 			
 		case ObjectRef.DBL_VECT : 

--- a/src/expression/Unit.java
+++ b/src/expression/Unit.java
@@ -310,7 +310,7 @@ public class Unit {
 		
 		/* split by dot · ALT 250 */
 		String[] unitsArray; 
-		units.replace("*", "·");
+		units = units.replace("*", "·");
 		unitsArray = units.split("·");
 		String[] unitPower;
 		Integer power;

--- a/src/grid/SpatialGrid.java
+++ b/src/grid/SpatialGrid.java
@@ -202,30 +202,45 @@ public class SpatialGrid implements Settable, Instantiable
 		
 		/* TODO should every grid always be instantiated as CONCN grid? */
 		this.newArray(ArrayType.CONCN, 0.0);
-		String conc = XmlHandler.obtainAttribute((Element) xmlElem, 
+		
+		//Try to get concentration as one double, attempting Expression conversion
+		Double concentrationDbl = XmlHandler.gatherDouble((Element) xmlElem, 
+				XmlRef.concentration);
+		
+		// If the attribute is an array, obtain as a String, and set the grid
+		//values via Array.dblFromString
+		if (concentrationDbl == null)
+		{
+			String conc = XmlHandler.obtainAttribute((Element) xmlElem, 
 				XmlRef.concentration, this.defaultXmlTag());
-		this.setTo(ArrayType.CONCN, conc);
+			this.setTo(ArrayType.CONCN, conc);
+		}
+		
+		else
+		{
+			this.setAllTo(ArrayType.CONCN, concentrationDbl);
+		}
+		
 		((EnvironmentContainer) parent).addSolute(this);
 		
 		/* Set default and biofilm diffusivity */
-		String s;
-		s = XmlHandler.obtainAttribute(xmlElem,
+		Double diffusivity = XmlHandler.obtainDouble(xmlElem,
 				XmlRef.defaultDiffusivity, this.defaultXmlTag());
-		this._defaultDiffusivity = Double.valueOf(s);
-		s = XmlHandler.gatherAttribute(xmlElem,
+		this._defaultDiffusivity = Double.valueOf(diffusivity);
+		diffusivity = XmlHandler.gatherDouble(xmlElem,
 				XmlRef.biofilmDiffusivity);
 		
 		/* identify whether biofilm diffusivity should be considered identical
 		 * to default diffusivity (in this case there is no need to identify
 		 * the biofilm region */
-		if ( Helper.isNullOrEmpty(s) || s.equals(this._defaultDiffusivity) )
+		if ( diffusivity == null || diffusivity == this._defaultDiffusivity )
 		{
 			this._diffusivity = DiffusivityType.ALL_SAME;
 			this._biofilmDiffusivity = this._defaultDiffusivity;
 		}
 		else
 		{
-			this._biofilmDiffusivity = Double.valueOf(s);
+			this._biofilmDiffusivity = diffusivity;
 			this._diffusivity = DiffusivityType.BIOMASS_SCALED;
 		}
 		

--- a/src/idynomics/Timer.java
+++ b/src/idynomics/Timer.java
@@ -54,21 +54,20 @@ public class Timer implements Instantiable, Settable
 	public void instantiate(Element xmlNode, Settable parent)
 	{
 		/* Get starting time step */
-		this.setCurrentTime( Double.valueOf( Helper.setIfNone( 
-				XmlHandler.gatherAttribute(
-				xmlNode, XmlRef.currentTime ), "0.0" ) ) );
+		this.setCurrentTime( Helper.setIfNone( XmlHandler.gatherDouble(
+				xmlNode, XmlRef.currentTime ), 0.0 ) );
 		
 		this.setCurrentIteration( Integer.valueOf( Helper.setIfNone( 
 				XmlHandler.gatherAttribute(
 				xmlNode, XmlRef.currentIter ), "0" ) ) );
 		
 		/* Get the time step. */
-		this.setTimeStepSize( Double.valueOf( XmlHandler.obtainAttribute(
-				xmlNode, XmlRef.timerStepSize, this.defaultXmlTag() ) ) );
+		this.setTimeStepSize( XmlHandler.obtainDouble (
+				xmlNode, XmlRef.timerStepSize, this.defaultXmlTag() ) );
 
 		/* Get the total time span. */
-		this.setEndOfSimulation( Double.valueOf( XmlHandler.obtainAttribute(
-				xmlNode, XmlRef.endOfSimulation, this.defaultXmlTag() ) ) );
+		this.setEndOfSimulation( XmlHandler.obtainDouble (
+				xmlNode, XmlRef.endOfSimulation, this.defaultXmlTag() ) );
 	}
 	
 	/*************************************************************************

--- a/src/linearAlgebra/Vector.java
+++ b/src/linearAlgebra/Vector.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
+import expression.Expression;
+import idynomics.Idynomics;
 import utility.ExtraMath;
 import utility.Helper;
 
@@ -269,8 +271,18 @@ public final class Vector
 		vectorString = Helper.removeWhitespace(vectorString);
 		String[] fields = vectorString.split(DELIMITER);
 		double[] vector = new double[fields.length];
-		for ( int i = 0; i < fields.length; i++ )		
-			vector[i] = Double.valueOf(fields[i]);
+		for ( int i = 0; i < fields.length; i++ )	
+		{
+			try
+			{
+				vector[i] = Double.parseDouble(fields[i]);
+			}
+			catch (NumberFormatException e)
+			{
+				vector[i] = 
+					new Expression( fields[i] ).format( Idynomics.unitSystem );
+			}
+		}
 		return vector;
 	}
 	

--- a/src/referenceLibrary/ClassRef.java
+++ b/src/referenceLibrary/ClassRef.java
@@ -178,13 +178,12 @@ public class ClassRef
 	public final static String densityScaled = 
 			aspect.calculated.DensityScaled.class.getName();
 	
-	/**
-	 * 
+	 /**
+	 *
 	 */
-	public final static String numberWithUnit = 
+	public final static String numberWithUnit =
 			aspect.calculated.NumberWithUnit.class.getName();
-	
-	
+
 	/* ************************************************************************
 	 * Class reference library : Aspects - Event
 	 */

--- a/src/shape/Dimension.java
+++ b/src/shape/Dimension.java
@@ -136,6 +136,7 @@ public class Dimension implements CanPrelaunchCheck, Settable,
 	{
 		Element elem = (Element) xmlElement;
 		String str;
+		Double dbl;
 		double val;
 		NodeList bndNodes;
 		Element bndElem;
@@ -157,8 +158,7 @@ public class Dimension implements CanPrelaunchCheck, Settable,
 		
 		/* The maximum has to be set. */
 		str = this.defaultXmlTag() + " " + this._dimName.name();
-		str = XmlHandler.obtainAttribute(elem, XmlRef.max, str);
-		val = Double.valueOf(str);
+		val = XmlHandler.obtainDouble(elem, XmlRef.max, str);
 		/* Convert from degrees to radians for angular dimensions */
 		if ( this.isAngular() )
 			val = Math.toRadians(val);
@@ -166,28 +166,32 @@ public class Dimension implements CanPrelaunchCheck, Settable,
 		
 		/* Set the real max from xml or equal to the compartment size. 
 		 * NOTE please add comments, what is the difference between real max and max? arent they both real?*/
-		str = XmlHandler.gatherAttribute(elem, XmlRef.realMax);
-		if ( !Helper.isNullOrEmpty(str) )
+		dbl = XmlHandler.gatherDouble(elem, XmlRef.realMax);
+		if ( dbl != null )
 		{
-			val = Double.valueOf(str);
+			val = dbl;
 			if ( this.isAngular() )
 				val = Math.toRadians(val);
 		}
 		this.setRealExtreme(val, 1);
 		
 		/* By default the minimum is 0.0 */
-		str = XmlHandler.gatherAttribute(elem, XmlRef.min);
-		val = Helper.isNullOrEmpty(str) ? 0.0 : Double.valueOf(str);
+		val = 0.0;
+		dbl = XmlHandler.gatherDouble(elem, XmlRef.min);
+		if (dbl != null)
+		{
+			val = dbl;
 		/* Convert from degrees to radians for angular dimensions */
-		if ( this.isAngular() )
-			val = Math.toRadians(val);
+			if ( this.isAngular() )
+				val = Math.toRadians(val);
+		}
 		this.setExtreme(val, 0);
 		
 		/* Set the real min from xml or equal to the compartment size. */
-		str = XmlHandler.gatherAttribute(elem, XmlRef.realMin);
-		if ( !Helper.isNullOrEmpty(str) )
+		dbl = XmlHandler.gatherDouble(elem, XmlRef.realMin);
+		if ( dbl != null )
 		{
-			val = Double.valueOf(str);
+			val = dbl;
 			if ( this.isAngular() )
 				val = Math.toRadians(val);
 		}
@@ -197,11 +201,11 @@ public class Dimension implements CanPrelaunchCheck, Settable,
 		double length = this.getLength();
 		
 		/* Fetch target resolution (or use length as default). */
-		str = XmlHandler.obtainAttribute(elem, XmlRef.targetResolutionAttribute,
+		dbl = XmlHandler.obtainDouble(elem, XmlRef.targetResolutionAttribute,
 				this.defaultXmlTag() + " " + this._dimName.name());
 		this._targetRes = length; 
-		if ( str != "" )
-			this._targetRes = Double.valueOf(str);
+		if ( dbl != null )
+			this._targetRes = dbl;
 		
 		/* Set theta dimension cyclic for a full circle, no matter what 
 		 * the user specified */

--- a/src/shape/Shape.java
+++ b/src/shape/Shape.java
@@ -189,15 +189,16 @@ public abstract class Shape implements
 		NodeList childNodes;
 		Element childElem;
 		String str;
+		Double dbl;
 		/* FIXME is this a correct implementation? This would create multiple
 		 * layers of voxels if we have a small target resolution eg 0.5µm. 
 		 * Shouldn't this be calculated from a target volume? or maybe just
 		 * equal to the resolution so we always have 1 layer in the
 		 * insignificant dimension. [Bas 27-11-2017] */
 		double insignificantDimsLength = 1.0;
-		str = XmlHandler.gatherAttribute(xmlElem, "insignificantDimsLength");
-		if ( str != null )
-			insignificantDimsLength = Double.parseDouble(str);
+		dbl = XmlHandler.gatherDouble(xmlElem, "insignificantDimsLength");
+		if ( dbl != null )
+			insignificantDimsLength = dbl;
 		/* Set up the dimensions. */
 		Dimension dim;
 		ResolutionCalculator rC;
@@ -623,9 +624,9 @@ public abstract class Shape implements
 				Element childElem = (Element) XmlHandler.getSpecific(
 						this._currElement, XmlRef.shapeDimension, 
 						XmlRef.nameAttribute, d.name());
-				String str = XmlHandler.gatherAttribute(childElem, 
+				Double dbl = XmlHandler.gatherDouble(childElem, 
 						XmlRef.realMax);
-				this._realDimExtremeName = Helper.isNullOrEmpty(str) ? d : null;
+				this._realDimExtremeName = dbl == null ? d : null;
 			}
 		}
 		else

--- a/src/shape/ShapeLibrary.java
+++ b/src/shape/ShapeLibrary.java
@@ -60,10 +60,9 @@ public final class ShapeLibrary
 		public void instantiate(Element xmlElem, Settable parent)
 		{
 			super.instantiate(xmlElem, parent);
-			// TODO read in as a Double
-			String str = XmlHandler.obtainAttribute(
-						xmlElem, XmlRef.volume, this.defaultXmlTag());
-			this._volume = Double.parseDouble(str);
+			
+			this._volume = XmlHandler.obtainDouble(
+					xmlElem, XmlRef.volume, this.defaultXmlTag());
 		}
 		
 		@Override

--- a/src/surface/collision/model/DefaultPullFunction.java
+++ b/src/surface/collision/model/DefaultPullFunction.java
@@ -27,10 +27,10 @@ public class  DefaultPullFunction implements CollisionFunction
 	 */
 	public void instantiate(Element xmlElement, Settable parent)
 	{
-		String forceScalar = XmlHandler.gatherAttribute(xmlElement, 
+		Double forceScalar = XmlHandler.gatherDouble(xmlElement, 
 				XmlRef.forceScalar);
-		if( !Helper.isNullOrEmpty( forceScalar ) )
-				this._forceScalar = Double.valueOf( forceScalar );
+		if( forceScalar != null )
+				this._forceScalar = forceScalar;
 	}
 	
 	/**

--- a/src/surface/collision/model/DefaultPushFunction.java
+++ b/src/surface/collision/model/DefaultPushFunction.java
@@ -27,10 +27,10 @@ public class DefaultPushFunction implements CollisionFunction
 	 */
 	public void instantiate(Element xmlElement, Settable parent)
 	{
-		String forceScalar = XmlHandler.gatherAttribute( xmlElement, 
+		Double forceScalar = XmlHandler.gatherDouble( xmlElement, 
 				XmlRef.forceScalar);
-		if( !Helper.isNullOrEmpty( forceScalar ) )
-				this._forceScalar = Double.valueOf( forceScalar );
+		if( forceScalar != null )
+				this._forceScalar = forceScalar;
 	}
 	
 	/**

--- a/src/surface/collision/model/HerzSoftSphere.java
+++ b/src/surface/collision/model/HerzSoftSphere.java
@@ -35,10 +35,10 @@ public class HerzSoftSphere implements CollisionFunction
 		 * In case of hugely different Young's moduli we may want to extend
 		 * on this and calculate the effective modulus on the fly
 		 */
-		String forceScalar = XmlHandler.gatherAttribute( xmlElement, 
+		Double forceScalar = XmlHandler.gatherDouble( xmlElement, 
 				XmlRef.forceScalar);
-		if( !Helper.isNullOrEmpty( forceScalar ) )
-				this._forceScalar = Double.valueOf( forceScalar );
+		if( forceScalar != null )
+				this._forceScalar = forceScalar;
 	}
 	
 	/**


### PR DESCRIPTION
…m XML. These methods check whether the string can be parsed as a Double, and if not, attempt to convert it using Expression.format(unitSystem). All calls to obtainAttribute and gatherAttribute methods have been checked and updated, if appropriate, to call obtainDouble or gatherDouble. The methods Vector.dblFromString and ObjectFactory.loadObject have also been updated to attempt to convert the double if it cannot be parsed. This should make NumberWithUnit obsolete, as aspects of class Double can now be declared with units in the protocol file and converted as they are loaded in. The NumberWithUnit class can be deleted if we are all agreed on this.